### PR TITLE
Merge branch 'master' into vectorIntrinsics

### DIFF
--- a/src/hotspot/cpu/aarch64/assembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.cpp
@@ -989,46 +989,6 @@ void entry(CodeBuffer *cb) {
     __ sha512su1(v17, __ T2D, v12, v3);                //       sha512su1               v17.2D, v12.2D, v3.2D
 
 // SVEVectorOp
-    __ sve_add(z17, __ D, z12, z3);                    //       add     z17.d, z12.d, z3.d
-    __ sve_sub(z29, __ D, z28, z16);                   //       sub     z29.d, z28.d, z16.d
-    __ sve_fadd(z6, __ D, z9, z28);                    //       fadd    z6.d, z9.d, z28.d
-    __ sve_fmul(z7, __ S, z4, z7);                     //       fmul    z7.s, z4.s, z7.s
-    __ sve_fsub(z9, __ S, z22, z8);                    //       fsub    z9.s, z22.s, z8.s
-    __ sve_abs(z27, __ B, p5, z30);                    //       abs     z27.b, p5/m, z30.b
-    __ sve_add(z26, __ H, p0, z16);                    //       add     z26.h, p0/m, z26.h, z16.h
-    __ sve_asr(z3, __ D, p6, z8);                      //       asr     z3.d, p6/m, z3.d, z8.d
-    __ sve_cnt(z21, __ D, p6, z26);                    //       cnt     z21.d, p6/m, z26.d
-    __ sve_lsl(z22, __ B, p0, z4);                     //       lsl     z22.b, p0/m, z22.b, z4.b
-    __ sve_lsr(z17, __ H, p0, z3);                     //       lsr     z17.h, p0/m, z17.h, z3.h
-    __ sve_mul(z1, __ B, p2, z6);                      //       mul     z1.b, p2/m, z1.b, z6.b
-    __ sve_neg(z9, __ S, p7, z7);                      //       neg     z9.s, p7/m, z7.s
-    __ sve_not(z22, __ H, p5, z5);                     //       not     z22.h, p5/m, z5.h
-    __ sve_smax(z8, __ B, p4, z30);                    //       smax    z8.b, p4/m, z8.b, z30.b
-    __ sve_smin(z17, __ D, p0, z11);                   //       smin    z17.d, p0/m, z17.d, z11.d
-    __ sve_sub(z28, __ S, p0, z26);                    //       sub     z28.s, p0/m, z28.s, z26.s
-    __ sve_fabs(z28, __ D, p3, z13);                   //       fabs    z28.d, p3/m, z13.d
-    __ sve_fadd(z16, __ S, p6, z5);                    //       fadd    z16.s, p6/m, z16.s, z5.s
-    __ sve_fdiv(z13, __ S, p2, z15);                   //       fdiv    z13.s, p2/m, z13.s, z15.s
-    __ sve_fmax(z26, __ S, p5, z11);                   //       fmax    z26.s, p5/m, z26.s, z11.s
-    __ sve_fmin(z22, __ S, p4, z4);                    //       fmin    z22.s, p4/m, z22.s, z4.s
-    __ sve_fmul(z19, __ S, p4, z17);                   //       fmul    z19.s, p4/m, z19.s, z17.s
-    __ sve_fneg(z14, __ D, p3, z2);                    //       fneg    z14.d, p3/m, z2.d
-    __ sve_frintm(z3, __ S, p5, z23);                  //       frintm  z3.s, p5/m, z23.s
-    __ sve_frintn(z6, __ S, p1, z17);                  //       frintn  z6.s, p1/m, z17.s
-    __ sve_frintp(z27, __ S, p4, z16);                 //       frintp  z27.s, p4/m, z16.s
-    __ sve_fsqrt(z2, __ S, p7, z3);                    //       fsqrt   z2.s, p7/m, z3.s
-    __ sve_fsub(z6, __ S, p4, z19);                    //       fsub    z6.s, p4/m, z6.s, z19.s
-    __ sve_fmla(z12, __ D, p5, z8, z24);               //       fmla    z12.d, p5/m, z8.d, z24.d
-    __ sve_fmls(z17, __ S, p0, z10, z23);              //       fmls    z17.s, p0/m, z10.s, z23.s
-    __ sve_fnmla(z19, __ S, p7, z13, z16);             //       fnmla   z19.s, p7/m, z13.s, z16.s
-    __ sve_fnmls(z0, __ D, p1, z14, z17);              //       fnmls   z0.d, p1/m, z14.d, z17.d
-    __ sve_mla(z8, __ S, p2, z22, z20);                //       mla     z8.s, p2/m, z22.s, z20.s
-    __ sve_mls(z27, __ S, p0, z3, z15);                //       mls     z27.s, p0/m, z3.s, z15.s
-    __ sve_and(z20, z7, z4);                           //       and     z20.d, z7.d, z4.d
-    __ sve_eor(z7, z0, z8);                            //       eor     z7.d, z0.d, z8.d
-    __ sve_orr(z19, z22, z4);                          //       orr     z19.d, z22.d, z4.d
-    __ sve_uzp1(z9, __ D, z22, z11);                   //       uzp1    z9.d, z22.d, z11.d
-    __ sve_uzp2(z5, __ H, z30, z16);                   //       uzp2    z5.h, z30.h, z16.h
     __ sve_add(z27, __ S, z29, z28);                   //       add     z27.s, z29.s, z28.s
     __ sve_sub(z26, __ D, z6, z9);                     //       sub     z26.d, z6.d, z9.d
     __ sve_fadd(z17, __ S, z7, z4);                    //       fadd    z17.s, z7.s, z4.s
@@ -1067,17 +1027,19 @@ void entry(CodeBuffer *cb) {
     __ sve_and(z28, z7, z0);                           //       and     z28.d, z7.d, z0.d
     __ sve_eor(z16, z19, z22);                         //       eor     z16.d, z19.d, z22.d
     __ sve_orr(z15, z9, z22);                          //       orr     z15.d, z9.d, z22.d
+    __ sve_uzp1(z25, __ S, z5, z30);                   //       uzp1    z25.s, z5.s, z30.s
+    __ sve_uzp2(z13, __ B, z22, z11);                  //       uzp2    z13.b, z22.b, z11.b
 
 // SVEReductionOp
-    __ sve_andv(v22, __ H, p3, z1);                    //       andv h22, p3, z1.h
-    __ sve_orv(v8, __ D, p5, z16);                     //       orv d8, p5, z16.d
-    __ sve_eorv(v15, __ S, p1, z4);                    //       eorv s15, p1, z4.s
-    __ sve_smaxv(v8, __ B, p1, z29);                   //       smaxv b8, p1, z29.b
-    __ sve_sminv(v28, __ D, p4, z29);                  //       sminv d28, p4, z29.d
-    __ sve_fminv(v9, __ S, p3, z2);                    //       fminv s9, p3, z2.s
-    __ sve_fmaxv(v28, __ S, p0, z7);                   //       fmaxv s28, p0, z7.s
-    __ sve_fadda(v26, __ S, p5, z17);                  //       fadda s26, p5, s26, z17.s
-    __ sve_uaddv(v8, __ D, p4, z21);                   //       uaddv d8, p4, z21.d
+    __ sve_andv(v13, __ S, p2, z20);                   //       andv s13, p2, z20.s
+    __ sve_orv(v25, __ B, p3, z4);                     //       orv b25, p3, z4.b
+    __ sve_eorv(v17, __ D, p2, z6);                    //       eorv d17, p2, z6.d
+    __ sve_smaxv(v4, __ D, p7, z16);                   //       smaxv d4, p7, z16.d
+    __ sve_sminv(v26, __ B, p2, z14);                  //       sminv b26, p2, z14.b
+    __ sve_fminv(v11, __ S, p7, z3);                   //       fminv s11, p7, z3.s
+    __ sve_fmaxv(v1, __ D, p6, z21);                   //       fmaxv d1, p6, z21.d
+    __ sve_fadda(v14, __ D, p2, z17);                  //       fadda d14, p2, d14, z17.d
+    __ sve_uaddv(v24, __ S, p1, z19);                  //       uaddv d24, p1, z19.s
 
     __ bind(forth);
 
@@ -1096,30 +1058,30 @@ void entry(CodeBuffer *cb) {
     0x9101a1a0,     0xb10a5cc8,     0xd10810aa,     0xf10fd061,
     0x120cb166,     0x321764bc,     0x52174681,     0x720c0227,
     0x9241018e,     0xb25a2969,     0xd278b411,     0xf26aad01,
-    0x14000000,     0x17ffffd7,     0x140002fd,     0x94000000,
-    0x97ffffd4,     0x940002fa,     0x3400000a,     0x34fffa2a,
-    0x34005eea,     0x35000008,     0x35fff9c8,     0x35005e88,
-    0xb400000b,     0xb4fff96b,     0xb4005e2b,     0xb500001d,
-    0xb5fff91d,     0xb5005ddd,     0x10000013,     0x10fff8b3,
-    0x10005d73,     0x90000013,     0x36300016,     0x3637f836,
-    0x36305cf6,     0x3758000c,     0x375ff7cc,     0x37585c8c,
+    0x14000000,     0x17ffffd7,     0x14000300,     0x94000000,
+    0x97ffffd4,     0x940002fd,     0x3400000a,     0x34fffa2a,
+    0x34005f4a,     0x35000008,     0x35fff9c8,     0x35005ee8,
+    0xb400000b,     0xb4fff96b,     0xb4005e8b,     0xb500001d,
+    0xb5fff91d,     0xb5005e3d,     0x10000013,     0x10fff8b3,
+    0x10005dd3,     0x90000013,     0x36300016,     0x3637f836,
+    0x36305d56,     0x3758000c,     0x375ff7cc,     0x37585cec,
     0x128313a0,     0x528a32c7,     0x7289173b,     0x92ab3acc,
     0xd2a0bf94,     0xf2c285e8,     0x9358722f,     0x330e652f,
     0x53067f3b,     0x93577c53,     0xb34a1aac,     0xd35a4016,
     0x13946c63,     0x93c3dbc8,     0x54000000,     0x54fff5a0,
-    0x54005a60,     0x54000001,     0x54fff541,     0x54005a01,
-    0x54000002,     0x54fff4e2,     0x540059a2,     0x54000002,
-    0x54fff482,     0x54005942,     0x54000003,     0x54fff423,
-    0x540058e3,     0x54000003,     0x54fff3c3,     0x54005883,
-    0x54000004,     0x54fff364,     0x54005824,     0x54000005,
-    0x54fff305,     0x540057c5,     0x54000006,     0x54fff2a6,
-    0x54005766,     0x54000007,     0x54fff247,     0x54005707,
-    0x54000008,     0x54fff1e8,     0x540056a8,     0x54000009,
-    0x54fff189,     0x54005649,     0x5400000a,     0x54fff12a,
-    0x540055ea,     0x5400000b,     0x54fff0cb,     0x5400558b,
-    0x5400000c,     0x54fff06c,     0x5400552c,     0x5400000d,
-    0x54fff00d,     0x540054cd,     0x5400000e,     0x54ffefae,
-    0x5400546e,     0x5400000f,     0x54ffef4f,     0x5400540f,
+    0x54005ac0,     0x54000001,     0x54fff541,     0x54005a61,
+    0x54000002,     0x54fff4e2,     0x54005a02,     0x54000002,
+    0x54fff482,     0x540059a2,     0x54000003,     0x54fff423,
+    0x54005943,     0x54000003,     0x54fff3c3,     0x540058e3,
+    0x54000004,     0x54fff364,     0x54005884,     0x54000005,
+    0x54fff305,     0x54005825,     0x54000006,     0x54fff2a6,
+    0x540057c6,     0x54000007,     0x54fff247,     0x54005767,
+    0x54000008,     0x54fff1e8,     0x54005708,     0x54000009,
+    0x54fff189,     0x540056a9,     0x5400000a,     0x54fff12a,
+    0x5400564a,     0x5400000b,     0x54fff0cb,     0x540055eb,
+    0x5400000c,     0x54fff06c,     0x5400558c,     0x5400000d,
+    0x54fff00d,     0x5400552d,     0x5400000e,     0x54ffefae,
+    0x540054ce,     0x5400000f,     0x54ffef4f,     0x5400546f,
     0xd40658e1,     0xd4014d22,     0xd4046543,     0xd4273f60,
     0xd44cad80,     0xd503201f,     0xd69f03e0,     0xd6bf03e0,
     0xd5033fdf,     0xd5033e9f,     0xd50332bf,     0xd61f0200,
@@ -1151,7 +1113,7 @@ void entry(CodeBuffer *cb) {
     0x791f226d,     0xf95aa2f3,     0xb9587bb7,     0x395f7176,
     0x795d9143,     0x399e7e08,     0x799a2697,     0x79df3422,
     0xb99c2624,     0xfd5c2374,     0xbd5fa1d9,     0xfd1d595a,
-    0xbd1b1869,     0x5800445b,     0x1800000b,     0xf8945060,
+    0xbd1b1869,     0x580044bb,     0x1800000b,     0xf8945060,
     0xd8000000,     0xf8ae6ba0,     0xf99a0080,     0x1a070035,
     0x3a0700a8,     0x5a0e0367,     0x7a11009b,     0x9a000380,
     0xba1e030c,     0xda0f0320,     0xfa030301,     0x0b340b11,
@@ -1207,87 +1169,88 @@ void entry(CodeBuffer *cb) {
     0x2eac856a,     0x6eaf85cd,     0x6ef085ee,     0x0eb6d6b4,
     0x4ea3d441,     0x4ef8d6f6,     0x0e209ffe,     0x4e309dee,
     0x0e649c62,     0x4e689ce6,     0x0ea59c83,     0x4ea99d07,
-    0x2e3adf38,     0x6e22dc20,     0x6e7ddf9b,     0x0e7f97dd,
-    0x4e6794c5,     0x0ea794c5,     0x4ebf97dd,     0x0e2dcd8b,
-    0x4e3bcf59,     0x4e62cc20,     0x2e6097fe,     0x6e629420,
-    0x2eb39651,     0x6ebe97bc,     0x0ebbcf59,     0x4eabcd49,
-    0x4efbcf59,     0x2e2efdac,     0x6e31fe0f,     0x6e6dfd8b,
-    0x0e2c656a,     0x4e336651,     0x0e7a6738,     0x4e7766d5,
-    0x0eb96717,     0x4ea26420,     0x0e32f630,     0x4e2cf56a,
-    0x4e68f4e6,     0x0e3e6fbc,     0x4e286ce6,     0x0e676cc5,
-    0x4e676cc5,     0x0eb66eb4,     0x4eb36e51,     0x0eb1f60f,
-    0x4eb3f651,     0x4efff7dd,     0x2e3c8f7a,     0x6e3e8fbc,
-    0x2e638c41,     0x6e7d8f9b,     0x2ea28c20,     0x6eb68eb4,
-    0x6efe8fbc,     0x0e31e60f,     0x4e2ee5ac,     0x4e6ce56a,
-    0x0e3e37bc,     0x4e3e37bc,     0x0e753693,     0x4e7836f6,
-    0x0eac356a,     0x4ea634a4,     0x4ee037fe,     0x2eb6e6b4,
-    0x6eaae528,     0x6ee0e7fe,     0x0e333e51,     0x4e2c3d6a,
-    0x0e7d3f9b,     0x4e643c62,     0x0eba3f38,     0x4ea63ca4,
-    0x4ee53c83,     0x2e2ae528,     0x6e38e6f6,     0x6e73e651,
-    0xba5fd3e3,     0x3a5f03e5,     0xfa411be4,     0x7a42cbe2,
-    0x93df03ff,     0xc820ffff,     0x8822fc7f,     0xc8247cbf,
-    0x88267fff,     0x4e010fe0,     0x4e081fe1,     0x4e0c1fe1,
-    0x4e0a1fe1,     0x4e071fe1,     0x4cc0ac3f,     0x05a08020,
-    0x05104fe0,     0x05505001,     0x05906fe2,     0x05d03005,
-    0x05101fea,     0x05901feb,     0x04b0e3e0,     0x0470e7e1,
-    0x042f9c20,     0x043f9c35,     0x047f9c20,     0x04ff9c20,
-    0x04299420,     0x04319160,     0x0461943e,     0x04a19020,
-    0x042053ff,     0x047f5401,     0x25208028,     0x2538cfe0,
-    0x2578d001,     0x25b8efe2,     0x25f8f007,     0x2538dfea,
-    0x25b8dfeb,     0xa400a3e0,     0xa420a7e0,     0xa4484be0,
-    0xa467afe0,     0xa4a8a7ea,     0xa547a814,     0xa4084ffe,
-    0xa55c53e0,     0xa5e1540b,     0xe400fbf6,     0xe408ffff,
-    0xe420e7e0,     0xe4484be0,     0xe460efe0,     0xe547e400,
-    0xe4014be0,     0xe4a84fe0,     0xe5f15000,     0x858043e0,
-    0x85a043ff,     0xe59f5d08,     0x0522c020,     0x05e6c0a4,
-    0x2401a001,     0x2443a051,     0x24858881,     0x24c78cd1,
-    0x240b8142,     0x24918213,     0x250f9001,     0x25508051,
-    0x25802491,     0x25df28c1,     0x25850c81,     0x251e10d1,
-    0x65816001,     0x65c36051,     0x65854891,     0x65c74cc1,
-    0x658b4152,     0x65d14203,     0x05733820,     0x05b238a4,
-    0x05f138e6,     0x0570396a,     0x25221420,     0x25640461,
-    0x25a614b2,     0x25eb0553,     0x25221c24,     0x25640c60,
-    0x25a61cb1,     0x25eb0d52,     0x1e601000,     0x1e603000,
-    0x1e621000,     0x1e623000,     0x1e641000,     0x1e643000,
-    0x1e661000,     0x1e663000,     0x1e681000,     0x1e683000,
-    0x1e6a1000,     0x1e6a3000,     0x1e6c1000,     0x1e6c3000,
-    0x1e6e1000,     0x1e6e3000,     0x1e701000,     0x1e703000,
-    0x1e721000,     0x1e723000,     0x1e741000,     0x1e743000,
-    0x1e761000,     0x1e763000,     0x1e781000,     0x1e783000,
-    0x1e7a1000,     0x1e7a3000,     0x1e7c1000,     0x1e7c3000,
-    0x1e7e1000,     0x1e7e3000,     0xf82d83a5,     0xf8380355,
-    0xf8381303,     0xf83a21f7,     0xf8353303,     0xf8285299,
-    0xf8304051,     0xf8217300,     0xf8246183,     0xf8bf815c,
-    0xf8ba0182,     0xf8b0103f,     0xf8ad201d,     0xf8b3322c,
-    0xf8b6538d,     0xf8be403f,     0xf8ba709c,     0xf8be60c4,
-    0xf8fe81fa,     0xf8e90188,     0xf8e01034,     0xf8f82002,
-    0xf8e93358,     0xf8f0507e,     0xf8ea4157,     0xf8e47050,
-    0xf8eb6148,     0xf86f8051,     0xf86a018c,     0xf86f104d,
-    0xf8672354,     0xf8703044,     0xf86451ec,     0xf87541f0,
-    0xf86b72f5,     0xf86c62fa,     0xb83c816e,     0xb8380181,
-    0xb83f120a,     0xb8272062,     0xb82d3233,     0xb8305023,
-    0xb82b40be,     0xb82873af,     0xb83e6280,     0xb8a782f4,
-    0xb8bc0375,     0xb8b91025,     0xb8b723f0,     0xb8a5312c,
-    0xb8bc53af,     0xb8b6427f,     0xb8bf71c5,     0xb8b061ff,
-    0xb8fb8214,     0xb8ec012b,     0xb8e6123e,     0xb8fb23dc,
-    0xb8e7328a,     0xb8ea5304,     0xb8f142d1,     0xb8e371fd,
-    0xb8f66273,     0xb87681e2,     0xb866020c,     0xb86b12ed,
-    0xb861227e,     0xb8653051,     0xb87051b6,     0xb86a43b5,
-    0xb87b736c,     0xb86363e1,     0xce312677,     0xce0e1b5b,
-    0xce7e8ed4,     0xce9ed858,     0xce768151,     0xce718451,
-    0xcec08300,     0xce628ad9,     0x04e30191,     0x04f0079d,
-    0x65dc0126,     0x65870887,     0x658806c9,     0x0416b7db,
-    0x0440021a,     0x04d09903,     0x04dabb55,     0x04138096,
-    0x04518071,     0x041008c1,     0x0497bce9,     0x045eb4b6,
-    0x040813c8,     0x04ca0171,     0x0481035c,     0x04dcadbc,
-    0x658098b0,     0x658d89ed,     0x6586957a,     0x65879096,
-    0x65829233,     0x04ddac4e,     0x6582b6e3,     0x6580a626,
-    0x6581b21b,     0x658dbc62,     0x65819266,     0x65f8150c,
-    0x65b72151,     0x65b05db3,     0x65f165c0,     0x04944ac8,
-    0x048f607b,     0x042430f4,     0x04a83007,     0x046432d3,
-    0x05eb6ac9,     0x05706fc5,     0x045a2c36,     0x04d83608,
-    0x0499248f,     0x040827a8,     0x04ca33bc,     0x65872c49,
-    0x658620fc,     0x6598363a,     0x04c132a8,
+    0x2ebad738,     0x6ea2d420,     0x6efdd79b,     0x2e3fdfdd,
+    0x6e27dcc5,     0x6e67dcc5,     0x0e7f97dd,     0x4e6d958b,
+    0x0ebb9759,     0x4ea29420,     0x0e20cffe,     0x4e22cc20,
+    0x4e73ce51,     0x2e7e97bc,     0x6e7b9759,     0x2eab9549,
+    0x6ebb9759,     0x0eaecdac,     0x4eb1ce0f,     0x4eedcd8b,
+    0x2e2cfd6a,     0x6e33fe51,     0x6e7aff38,     0x0e3766d5,
+    0x4e396717,     0x0e626420,     0x4e726630,     0x0eac656a,
+    0x4ea864e6,     0x0e3ef7bc,     0x4e28f4e6,     0x4e67f4c5,
+    0x0e276cc5,     0x4e366eb4,     0x0e736e51,     0x4e716e0f,
+    0x0eb36e51,     0x4ebf6fdd,     0x0ebcf77a,     0x4ebef7bc,
+    0x4ee3f441,     0x2e3d8f9b,     0x6e228c20,     0x2e768eb4,
+    0x6e7e8fbc,     0x2eb18e0f,     0x6eae8dac,     0x6eec8d6a,
+    0x0e3ee7bc,     0x4e3ee7bc,     0x4e75e693,     0x0e3836f6,
+    0x4e2c356a,     0x0e6634a4,     0x4e6037fe,     0x0eb636b4,
+    0x4eaa3528,     0x4ee037fe,     0x2eb3e651,     0x6eace56a,
+    0x6efde79b,     0x0e243c62,     0x4e3a3f38,     0x0e663ca4,
+    0x4e653c83,     0x0eaa3d28,     0x4eb83ef6,     0x4ef33e51,
+    0x2e2fe5cd,     0x6e26e4a4,     0x6e7ee7bc,     0xba5fd3e3,
+    0x3a5f03e5,     0xfa411be4,     0x7a42cbe2,     0x93df03ff,
+    0xc820ffff,     0x8822fc7f,     0xc8247cbf,     0x88267fff,
+    0x4e010fe0,     0x4e081fe1,     0x4e0c1fe1,     0x4e0a1fe1,
+    0x4e071fe1,     0x4cc0ac3f,     0x05a08020,     0x05104fe0,
+    0x05505001,     0x05906fe2,     0x05d03005,     0x05101fea,
+    0x05901feb,     0x04b0e3e0,     0x0470e7e1,     0x042f9c20,
+    0x043f9c35,     0x047f9c20,     0x04ff9c20,     0x04299420,
+    0x04319160,     0x0461943e,     0x04a19020,     0x042053ff,
+    0x047f5401,     0x25208028,     0x2538cfe0,     0x2578d001,
+    0x25b8efe2,     0x25f8f007,     0x2538dfea,     0x25b8dfeb,
+    0xa400a3e0,     0xa420a7e0,     0xa4484be0,     0xa467afe0,
+    0xa4a8a7ea,     0xa547a814,     0xa4084ffe,     0xa55c53e0,
+    0xa5e1540b,     0xe400fbf6,     0xe408ffff,     0xe420e7e0,
+    0xe4484be0,     0xe460efe0,     0xe547e400,     0xe4014be0,
+    0xe4a84fe0,     0xe5f15000,     0x858043e0,     0x85a043ff,
+    0xe59f5d08,     0x0522c020,     0x05e6c0a4,     0x2401a001,
+    0x2443a051,     0x24858881,     0x24c78cd1,     0x240b8142,
+    0x24918213,     0x250f9001,     0x25508051,     0x25802491,
+    0x25df28c1,     0x25850c81,     0x251e10d1,     0x65816001,
+    0x65c36051,     0x65854891,     0x65c74cc1,     0x658b4152,
+    0x65d14203,     0x05733820,     0x05b238a4,     0x05f138e6,
+    0x0570396a,     0x25221420,     0x25640461,     0x25a614b2,
+    0x25eb0553,     0x25221c24,     0x25640c60,     0x25a61cb1,
+    0x25eb0d52,     0x1e601000,     0x1e603000,     0x1e621000,
+    0x1e623000,     0x1e641000,     0x1e643000,     0x1e661000,
+    0x1e663000,     0x1e681000,     0x1e683000,     0x1e6a1000,
+    0x1e6a3000,     0x1e6c1000,     0x1e6c3000,     0x1e6e1000,
+    0x1e6e3000,     0x1e701000,     0x1e703000,     0x1e721000,
+    0x1e723000,     0x1e741000,     0x1e743000,     0x1e761000,
+    0x1e763000,     0x1e781000,     0x1e783000,     0x1e7a1000,
+    0x1e7a3000,     0x1e7c1000,     0x1e7c3000,     0x1e7e1000,
+    0x1e7e3000,     0xf8388355,     0xf8380303,     0xf83a11f7,
+    0xf8352303,     0xf8283299,     0xf8305051,     0xf8214300,
+    0xf8247183,     0xf83f615c,     0xf8ba8182,     0xf8b0003f,
+    0xf8ad101d,     0xf8b3222c,     0xf8b6338d,     0xf8be503f,
+    0xf8ba409c,     0xf8be70c4,     0xf8be61fa,     0xf8e98188,
+    0xf8e00034,     0xf8f81002,     0xf8e92358,     0xf8f0307e,
+    0xf8ea5157,     0xf8e44050,     0xf8eb7148,     0xf8ef6051,
+    0xf86a818c,     0xf86f004d,     0xf8671354,     0xf8702044,
+    0xf86431ec,     0xf87551f0,     0xf86b42f5,     0xf86c72fa,
+    0xf87c616e,     0xb8388181,     0xb83f020a,     0xb8271062,
+    0xb82d2233,     0xb8303023,     0xb82b50be,     0xb82843af,
+    0xb83e7280,     0xb82762f4,     0xb8bc8375,     0xb8b90025,
+    0xb8b713f0,     0xb8a5212c,     0xb8bc33af,     0xb8b6527f,
+    0xb8bf41c5,     0xb8b071ff,     0xb8bb6214,     0xb8ec812b,
+    0xb8e6023e,     0xb8fb13dc,     0xb8e7228a,     0xb8ea3304,
+    0xb8f152d1,     0xb8e341fd,     0xb8f67273,     0xb8f661e2,
+    0xb866820c,     0xb86b02ed,     0xb861127e,     0xb8652051,
+    0xb87031b6,     0xb86a53b5,     0xb87b436c,     0xb86373e1,
+    0xb8786233,     0xce3a3b69,     0xce167a86,     0xce7e8c58,
+    0xce8aba3a,     0xce718051,     0xce798700,     0xcec08056,
+    0xce638991,     0x04bc03bb,     0x04e904da,     0x658400f1,
+    0x6596092f,     0x65d40762,     0x0496b805,     0x0440072e,
+    0x04d0975b,     0x041ab418,     0x04139006,     0x0411812f,
+    0x04100b65,     0x0417b694,     0x04deaa0a,     0x04481046,
+    0x04ca1c5d,     0x04411dd6,     0x049cb2fb,     0x65c08d42,
+    0x658d9aca,     0x65869603,     0x65c79201,     0x65828d8c,
+    0x04dda290,     0x65c2a4e5,     0x65c0be0c,     0x6581a386,
+    0x65cda624,     0x65818e6d,     0x65a01638,     0x65be2677,
+    0x65a74410,     0x65ea7911,     0x04025774,     0x0407728f,
+    0x042030fc,     0x04b63270,     0x0476312f,     0x05be68b9,
+    0x052b6ecd,     0x049a2a8d,     0x04182c99,     0x04d928d1,
+    0x04c83e04,     0x040a29da,     0x65873c6b,     0x65c63aa1,
+    0x65d82a2e,     0x04812678,
   };
 // END  Generated code -- do not edit
 

--- a/src/hotspot/share/opto/callnode.cpp
+++ b/src/hotspot/share/opto/callnode.cpp
@@ -490,7 +490,6 @@ void JVMState::format(PhaseRegAlloc *regalloc, const Node *n, outputStream* st) 
         ciField* cifield;
         if (iklass != NULL) {
           st->print(" [");
-          iklass->nof_nonstatic_fields(); // FIXME: iklass->_nonstatic_fields == NULL
           cifield = iklass->nonstatic_field_at(0);
           cifield->print_name_on(st);
           format_helper(regalloc, st, fld_node, ":", 0, &scobjs);


### PR DESCRIPTION
Fixed assembler_aarch64.cpp merge issue, and revert JDK-8253623 as the real fix JDK-8255448 was in.