### PR TITLE
Add individual unsigned comparison enum consts in BoolTest

### DIFF
--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
@@ -2113,18 +2113,18 @@ void C2_MacroAssembler::get_elem(BasicType typ, XMMRegister dst, XMMRegister src
 void C2_MacroAssembler::evpcmp(BasicType typ, KRegister kdmask, KRegister ksmask, XMMRegister src1, AddressLiteral adr, int comparison, int vector_len, Register scratch) {
   switch(typ) {
     case T_BYTE:
-      evpcmpb(kdmask, ksmask, src1, adr, comparison, vector_len, /*signed*/ true, scratch);
+      evpcmpb(kdmask, ksmask, src1, adr, comparison, /*signed*/ true, vector_len, scratch);
       break;
     case T_SHORT:
-      evpcmpw(kdmask, ksmask, src1, adr, comparison, vector_len, /*signed*/ true, scratch);
+      evpcmpw(kdmask, ksmask, src1, adr, comparison, /*signed*/ true, vector_len, scratch);
       break;
     case T_INT:
     case T_FLOAT:
-      evpcmpd(kdmask, ksmask, src1, adr, comparison, vector_len, /*signed*/ true, scratch);
+      evpcmpd(kdmask, ksmask, src1, adr, comparison, /*signed*/ true, vector_len, scratch);
       break;
     case T_LONG:
     case T_DOUBLE:
-      evpcmpq(kdmask, ksmask, src1, adr, comparison, vector_len, /*signed*/ true, scratch);
+      evpcmpq(kdmask, ksmask, src1, adr, comparison, /*signed*/ true, vector_len, scratch);
       break;
     default:
       assert(false,"Should not reach here.");

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -1227,10 +1227,7 @@ static inline Assembler::AvxVectorLen vector_length_encoding(const MachNode* use
 }
 
 static inline bool is_unsigned_booltest_pred(int bt) {
-  return  (bt == BoolTest::ule ||
-           bt == BoolTest::ult ||
-           bt == BoolTest::uge ||
-           bt == BoolTest::ugt);
+  return  ((bt & BoolTest::unsigned_compare) == BoolTest::unsigned_compare);
 }
 
 class Node::PD {

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -1227,9 +1227,11 @@ static inline Assembler::AvxVectorLen vector_length_encoding(const MachNode* use
 }
 
 static inline bool is_unsigned_booltest_pred(int bt) {
-  return  ((bt & BoolTest::unsigned_compare) == BoolTest::unsigned_compare);
+  return  (bt == BoolTest::ule ||
+           bt == BoolTest::ult ||
+           bt == BoolTest::uge ||
+           bt == BoolTest::ugt);
 }
-
 
 class Node::PD {
 public:
@@ -2138,14 +2140,23 @@ void Compile::reshape_address(AddPNode* addp) {
 }
 
 static inline Assembler::ComparisonPredicate booltest_pred_to_comparison_pred(int bt) {
-  bt = bt & ~BoolTest::unsigned_compare;
   switch (bt) {
-    case BoolTest::eq: return Assembler::eq;
-    case BoolTest::ne: return Assembler::neq;
-    case BoolTest::le: return Assembler::le;
-    case BoolTest::ge: return Assembler::nlt;
-    case BoolTest::lt: return Assembler::lt;
-    case BoolTest::gt: return Assembler::nle;
+    case BoolTest::eq:
+      return Assembler::eq;
+    case BoolTest::ne:
+      return Assembler::neq;
+    case BoolTest::le:
+    case BoolTest::ule:
+      return Assembler::le;
+    case BoolTest::ge:
+    case BoolTest::uge:
+      return Assembler::nlt;
+    case BoolTest::lt:
+    case BoolTest::ult:
+      return Assembler::lt;
+    case BoolTest::gt:
+    case BoolTest::ugt:
+      return Assembler::nle;
     default : ShouldNotReachHere(); return Assembler::_false;
   }
 }

--- a/src/hotspot/share/opto/subnode.hpp
+++ b/src/hotspot/share/opto/subnode.hpp
@@ -304,9 +304,10 @@ public:
 // Convert condition codes to a boolean test value (0 or -1).
 // We pick the values as 3 bits; the low order 2 bits we compare against the
 // condition codes, the high bit flips the sense of the result.
+// For vector compares, additionaly, the 4th bit indicates if the compare is unsigned
 struct BoolTest {
-  enum mask { eq = 0, ne = 4, le = 5, ge = 7, lt = 3, gt = 1, overflow = 2, no_overflow = 6, never = 8, illegal = 9,
-                              unsigned_compare = 16 };
+  enum mask { eq = 0, ne = 4, le = 5, ge = 7, lt = 3, gt = 1, overflow = 2, no_overflow = 6, never = 8, illegal = 9, unsigned_compare = 16,
+              ule = unsigned_compare | le, uge = unsigned_compare | ge, ult = unsigned_compare | lt, ugt = unsigned_compare | gt };
   mask _test;
   BoolTest( mask btm ) : _test(btm) {}
   const Type *cc2logical( const Type *CC ) const;

--- a/src/hotspot/share/opto/subnode.hpp
+++ b/src/hotspot/share/opto/subnode.hpp
@@ -309,7 +309,7 @@ struct BoolTest {
   enum mask { eq = 0, ne = 4, le = 5, ge = 7, lt = 3, gt = 1, overflow = 2, no_overflow = 6, never = 8, illegal = 9, unsigned_compare = 16,
               ule = unsigned_compare | le, uge = unsigned_compare | ge, ult = unsigned_compare | lt, ugt = unsigned_compare | gt };
   mask _test;
-  BoolTest( mask btm ) : _test(btm) {}
+  BoolTest( mask btm ) : _test(btm) { assert((btm & unsigned_compare) == 0, "unsupported");}
   const Type *cc2logical( const Type *CC ) const;
   // Commute the test.  I use a small table lookup.  The table is created as
   // a simple char array where each element is the ASCII version of a 'mask'


### PR DESCRIPTION
Added individual unsigned comparison enum consts in BoolTest. Also fixed a bug introduced in previous commit.